### PR TITLE
Fix GridFS handling in picture service

### DIFF
--- a/src/Service/PictureService.php
+++ b/src/Service/PictureService.php
@@ -20,14 +20,7 @@ class PictureService
 
     public function storePicture(string $filePath, string $originalName): Picture
     {
-        // Create a new File document
-        $file = new File();
-        $file->filename = $originalName;
-        $file->uploadDate = new \DateTime();
-
-        // Simulate storing the file content (e.g., in a database or file system)
-        $fileContent = file_get_contents($filePath);
-        $file->content = $fileContent; // Add a `content` field to the File document if needed
+        $file = $this->dm->getRepository(File::class)->uploadFromFile($filePath, $originalName);
 
         // Assign a mock ID for testing purposes if not already set
         if (! $file->id) {
@@ -37,13 +30,13 @@ class PictureService
         $this->dm->persist($file);
 
         // Generate description and embeddings
+        $fileContent = file_get_contents($filePath);
         $imageData = $fileContent; // Placeholder for resizing logic
         [$description, $embeddings] = $this->generateDescriptionAndEmbeddings($imageData);
 
         // Create a new Picture document
         $picture = new Picture();
         $picture->file = $file;
-        $picture->fileId = $file->id; // Ensure the fileId is set from the File document
         $picture->resizedImage = $imageData;
         $picture->description = $description;
         $picture->embeddings = $embeddings;

--- a/tests/PictureServiceTest.php
+++ b/tests/PictureServiceTest.php
@@ -8,6 +8,7 @@ use App\Document\File;
 use App\Document\Picture;
 use App\Service\PictureService;
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Repository\GridFSRepository;
 use PHPUnit\Framework\TestCase;
 
 use function file_put_contents;
@@ -58,6 +59,20 @@ class PictureServiceTest extends TestCase
         $file->id = 'mockFileId';
         $file->filename = $originalName;
         $file->uploadDate = new \DateTime();
+
+        $bucketMock = $this->createMock(GridFSRepository::class);
+
+        $bucketMock
+            ->expects($this->once())
+            ->method('uploadFromFile')
+            ->with($filePath, $originalName)
+            ->willReturn($file);
+
+        $this->documentManagerMock
+            ->expects($this->once())
+            ->method('getRepository')
+            ->with(File::class)
+            ->willReturn($bucketMock);
 
         $this->documentManagerMock
             ->expects($this->exactly(2))


### PR DESCRIPTION
Fixes the handling of GridFS files in ODM - these need to be uploaded using the repository instead of being persisted like other documents.