### PR TITLE
Import GitHub contributors

### DIFF
--- a/.env
+++ b/.env
@@ -16,6 +16,9 @@
 
 SYMFONY_IDE=phpstorm
 
+# Create a GitHub token to download contributors: https://github.com/settings/tokens
+GITHUB_TOKEN=
+
 ###> symfony/framework-bundle ###
 APP_ENV=dev
 APP_SECRET=

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "symfony/stimulus-bundle": "^2.24",
         "symfony/twig-bundle": "*",
         "symfony/validator": "*",
+        "symfony/var-exporter": "7.2.*",
         "symfony/yaml": "*",
         "twig/extra-bundle": "^3.21",
         "twig/twig": "^3.21.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ed91b4a01da76f564d726cffc6411c5",
+    "content-hash": "83e53112bb0aaec29bdb852a597fa50b",
     "packages": [
         {
             "name": "composer/semver",
@@ -5102,21 +5102,20 @@
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.3.0-BETA1",
+            "version": "v7.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "6d25a2377310c85f0400797e4f07c303df00bd74"
+                "reference": "422b8de94c738830a1e071f59ad14d67417d7007"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/6d25a2377310c85f0400797e4f07c303df00bd74",
-                "reference": "6d25a2377310c85f0400797e4f07c303df00bd74",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/422b8de94c738830a1e071f59ad14d67417d7007",
+                "reference": "422b8de94c738830a1e071f59ad14d67417d7007",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3"
+                "php": ">=8.2"
             },
             "require-dev": {
                 "symfony/property-access": "^6.4|^7.0",
@@ -5159,7 +5158,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.3.0-BETA1"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.2.6"
             },
             "funding": [
                 {
@@ -5175,7 +5174,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-02T08:36:13+00:00"
+            "time": "2025-05-02T08:36:00+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -21,6 +21,7 @@
         <exclude name="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
         <exclude name="Generic.Formatting.MultipleStatementAlignment"/>
+        <exclude name="Generic.Files.LineLength"/>
     </rule>
 
     <rule name="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">

--- a/src/Command/ImportContributorsCommand.php
+++ b/src/Command/ImportContributorsCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Document\Face;
+use App\Service\PictureService;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+#[AsCommand(
+    name: 'app:import-contributors',
+    description: 'Import contributors from a GitHub project and save them in the database.',
+)]
+class ImportContributorsCommand
+{
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private DocumentManager $documentManager,
+        private PictureService $pictureService
+    ) {
+    }
+
+    public function __invoke(
+        #[Argument]
+        string $repository,
+        OutputInterface $output,
+    ): int {
+        $output->writeln(sprintf('Fetching contributors for repository: %s', $repository));
+
+        $url = sprintf('https://api.github.com/repos/%s/contributors', $repository);
+        $response = $this->httpClient->request('GET', $url);
+        $contributors = $response->toArray();
+
+        foreach ($contributors as $contributor) {
+            $output->writeln(sprintf('Processing contributor: %s', $contributor['login']));
+            file_put_contents(
+                $imageFile = tempnam(sys_get_temp_dir(), $contributor['login']),
+                $this->httpClient->request('GET', $contributor['avatar_url'])->getContent(),
+            );
+
+            $this->pictureService->storePicture(
+                $imageFile,
+                $contributor['avatar_url'],
+                $contributor['login'],
+            );
+        }
+
+        $this->documentManager->flush();
+
+        $output->writeln('Contributors imported successfully.');
+
+        return Command::SUCCESS;
+    }
+}
+

--- a/src/Command/ImportContributorsCommand.php
+++ b/src/Command/ImportContributorsCommand.php
@@ -36,6 +36,7 @@ class ImportContributorsCommand
         ['count' => $count, 'iterator' => $iterator] = $this->github->getContributors($repository);
 
         $progressBar = new ProgressBar($output);
+        $progressBar->setFormat(ProgressBar::FORMAT_VERY_VERBOSE);
         $progressBar->start($count);
         $totalContributors = 0;
 
@@ -45,8 +46,10 @@ class ImportContributorsCommand
             $this->importContributors($contributors, $output);
         }
 
+        $progressBar->setMaxSteps($totalContributors);
         $progressBar->finish();
 
+        $output->writeln('');
         $output->writeln(sprintf('%d contributors imported successfully.', $totalContributors));
 
         return Command::SUCCESS;

--- a/src/Service/GitHub.php
+++ b/src/Service/GitHub.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class GitHub
+{
+    private readonly array $requestOptions;
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        #[Autowire(env: 'GITHUB_TOKEN')]
+        #[\SensitiveParameter]
+        string $gitHubApiToken,
+    ) {
+        if (! $gitHubApiToken) {
+            throw new \RuntimeException('GITHUB_TOKEN environment variable is required.');
+        }
+
+        $this->requestOptions = [
+            // Set github token header
+            'headers' => [
+                'Authorization' => sprintf('Bearer %s', $gitHubApiToken),
+                'X-GitHub-Api-Version' => '2022-11-28',
+            ],
+        ];
+    }
+
+    /** @return array{count: int, iterator: \Generator} */
+    public function getContributors(string $repository, int $perPage = 10): array
+    {
+        // Get the first page of contributors to count total
+        $url = sprintf('https://api.github.com/repos/%s/contributors?per_page=%d', $repository, $perPage);
+        $response = $this->httpClient->request('GET', $url, $this->requestOptions);
+        $links = $this->parseLinkHeader($response->getHeaders()['link'] ?? []);
+        $nextLink = $links['next'] ?? null;
+        $lastLink = $links['last'] ?? null;
+        $count = 1;
+        if ($lastLink) {
+            parse_str(parse_url($lastLink, PHP_URL_QUERY), $query);
+            $count = isset($query['page']) ? filter_var($query['page'], FILTER_VALIDATE_INT) : null;
+        }
+
+        return [
+            'count' => $count * $perPage,
+            'iterator' => (function () use ($nextLink) {
+                while ($nextLink) {
+                    $response = $this->httpClient->request('GET', $nextLink, $this->requestOptions);
+                    $nextLink = $this->parseLinkHeader($response->getHeaders()['link'])['next'] ?? null;
+
+                    yield $response->toArray();
+                }
+            })(),
+        ];
+    }
+
+    /**
+     * @param string[] $linkHeaders
+     *
+     * @return array<string, string>
+     */
+    private function parseLinkHeader(array $linkHeaders): array
+    {
+        $links = [];
+        $parts = array_merge(...array_map(static fn ($linkHeader) => explode(',', $linkHeader), $linkHeaders));
+
+        foreach ($parts as $part) {
+            preg_match('/<([^>]+)>;\s*rel="([^"]+)"/', trim($part), $matches);
+            if (count($matches) === 3) {
+                $links[$matches[2]] = $matches[1];
+            }
+        }
+
+        return $links;
+    }
+}

--- a/src/Service/PictureService.php
+++ b/src/Service/PictureService.php
@@ -20,6 +20,7 @@ class PictureService
     {
     }
 
+    /** @param string $filePath File path or content */
     public function storePicture(string $filePath, string $originalFileName, string $name = ''): Face
     {
         $file = $this->dm->getRepository(Picture::class)->uploadFromFile($filePath, $originalFileName);

--- a/src/Service/PictureService.php
+++ b/src/Service/PictureService.php
@@ -20,7 +20,6 @@ class PictureService
     {
     }
 
-    /** @param string $filePath File path or content */
     public function storePicture(string $filePath, string $originalFileName, string $name = ''): Face
     {
         $file = $this->dm->getRepository(Picture::class)->uploadFromFile($filePath, $originalFileName);

--- a/tests/Command/ImportContributorsCommandTest.php
+++ b/tests/Command/ImportContributorsCommandTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\ImportContributorsCommand;
+use App\Service\GitHub;
+use App\Service\PictureService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class ImportContributorsCommandTest extends TestCase
+{
+    public function testInvokeImportsContributorsAndStoresPictures(): void
+    {
+        $contributors = [
+            [
+                'login' => 'alice',
+                'avatar_url' => 'https://avatars.githubusercontent.com/u/1?v=4',
+            ],
+            [
+                'login' => 'bob',
+                'avatar_url' => 'https://avatars.githubusercontent.com/u/2?v=4',
+            ],
+        ];
+
+        $github = $this->createMock(GitHub::class);
+        $github->expects($this->once())
+            ->method('getContributors')
+            ->with('owner/repo')
+            ->willReturn([
+                'count' => 2,
+                'iterator' => new \ArrayIterator([ $contributors ]),
+            ]);
+
+        $responses = [
+            new MockResponse('alice_image_content'),
+            new MockResponse('bob_image_content'),
+        ];
+        $httpClient = new MockHttpClient($responses);
+
+        $pictureService = $this->createMock(PictureService::class);
+        $pictureService->expects($this->exactly(2))
+            ->method('storePicture')
+            ->with(
+                $this->isType('string'),
+                $this->logicalOr(
+                    $this->equalTo($contributors[0]['avatar_url']),
+                    $this->equalTo($contributors[1]['avatar_url']),
+                ),
+                $this->logicalOr(
+                    $this->equalTo($contributors[0]['login']),
+                    $this->equalTo($contributors[1]['login']),
+                ),
+            );
+
+        $command = new ImportContributorsCommand($github, $httpClient, $pictureService);
+
+        $output = new BufferedOutput();
+        $result = $command->__invoke('owner/repo', $output);
+
+        $this->assertSame(0, $result);
+        $display = $output->fetch();
+        $this->assertStringContainsString('Fetching contributors for repository: owner/repo', $display);
+        $this->assertStringContainsString('2 contributors imported successfully.', $display);
+    }
+}

--- a/tests/Service/GitHubTest.php
+++ b/tests/Service/GitHubTest.php
@@ -44,7 +44,6 @@ class GitHubTest extends TestCase
         $github = new GitHub($httpClient, 'dummy_token');
 
         $method = new \ReflectionMethod(GitHub::class, 'parseLinkHeader');
-        $method->setAccessible(true);
 
         $headers = ['<https://api.github.com/repos/owner/repo/contributors?page=2>; rel="next", <https://api.github.com/repos/owner/repo/contributors?page=3>; rel="last"'];
 

--- a/tests/Service/GitHubTest.php
+++ b/tests/Service/GitHubTest.php
@@ -30,8 +30,8 @@ class GitHubTest extends TestCase
         $this->assertEquals(30, $result['count']); // 3 pages * 10 per page
 
         $contributors = iterator_to_array($result['iterator']);
-        $this->assertCount(1, $contributors);
-        $this->assertEquals([['login' => 'user3'], ['login' => 'user4']], $contributors[0]);
+        $this->assertCount(2, $contributors);
+        $this->assertEquals([[['login' => 'user1'], ['login' => 'user2']], [['login' => 'user3'], ['login' => 'user4']]], $contributors);
 
         // Verify the requested URLs
         $this->assertStringContainsString('/repos/owner/repo/contributors', $responses[0]->getRequestUrl());
@@ -67,6 +67,6 @@ class GitHubTest extends TestCase
         $result = $github->getContributors('owner/repo');
 
         $this->assertGreaterThanOrEqual(1, $result['count']);
-        $this->assertEquals([], iterator_to_array($result['iterator']));
+        $this->assertEquals([[['login' => 'user1']]], iterator_to_array($result['iterator']));
     }
 }

--- a/tests/Service/GitHubTest.php
+++ b/tests/Service/GitHubTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Service\GitHub;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class GitHubTest extends TestCase
+{
+    public function testGetContributors(): void
+    {
+        $responses = [
+            new MockResponse(json_encode([['login' => 'user1'], ['login' => 'user2']]), [
+                'response_headers' => ['Link' => '<https://api.github.com/repos/owner/repo/contributors?per_page=10&page=2>; rel="next", <https://api.github.com/repos/owner/repo/contributors?per_page=10&page=3>; rel="last"'],
+            ]),
+            new MockResponse(json_encode([['login' => 'user3'], ['login' => 'user4']]), [
+                'response_headers' => ['Link' => '<https://api.github.com/repos/owner/repo/contributors?per_page=10&page=3>; rel="last"'],
+            ]),
+        ];
+
+        $httpClient = new MockHttpClient($responses);
+        $github = new GitHub($httpClient, 'dummy_token');
+
+        $result = $github->getContributors('owner/repo');
+
+        $this->assertEquals(30, $result['count']); // 3 pages * 10 per page
+
+        $contributors = iterator_to_array($result['iterator']);
+        $this->assertCount(1, $contributors);
+        $this->assertEquals([['login' => 'user3'], ['login' => 'user4']], $contributors[0]);
+
+        // Verify the requested URLs
+        $this->assertStringContainsString('/repos/owner/repo/contributors', $responses[0]->getRequestUrl());
+        $this->assertStringContainsString('per_page=10', $responses[0]->getRequestUrl());
+    }
+
+    public function testParseLinkHeader(): void
+    {
+        $httpClient = new MockHttpClient();
+        $github = new GitHub($httpClient, 'dummy_token');
+
+        $method = new \ReflectionMethod(GitHub::class, 'parseLinkHeader');
+        $method->setAccessible(true);
+
+        $headers = ['<https://api.github.com/repos/owner/repo/contributors?page=2>; rel="next", <https://api.github.com/repos/owner/repo/contributors?page=3>; rel="last"'];
+
+        $result = $method->invoke($github, $headers);
+
+        $this->assertEquals([
+            'next' => 'https://api.github.com/repos/owner/repo/contributors?page=2',
+            'last' => 'https://api.github.com/repos/owner/repo/contributors?page=3',
+        ], $result);
+    }
+
+    public function testGetContributorsWithNoMorePages(): void
+    {
+        $response = new MockResponse(json_encode([['login' => 'user1']]), [
+            'response_headers' => [],
+        ]);
+
+        $httpClient = new MockHttpClient($response);
+        $github = new GitHub($httpClient, 'dummy_token');
+
+        $result = $github->getContributors('owner/repo');
+
+        $this->assertGreaterThanOrEqual(1, $result['count']);
+        $this->assertEquals([], iterator_to_array($result['iterator']));
+    }
+}


### PR DESCRIPTION
This command will import all the contributors returned by the GitHub API for a specific project.

```
❯ bin/console app:import-contributors symfony/symfony               
Fetching contributors for repository: symfony/symfony
 352/352 [============================] 100%   35 s/35 s  
352 contributors imported successfully.
```