### PR TITLE
Add event listener to fix vector search indexes

### DIFF
--- a/src/Doctrine/ODM/MongoDB/Listener/VectorSearchIndexListener.php
+++ b/src/Doctrine/ODM/MongoDB/Listener/VectorSearchIndexListener.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Doctrine\ODM\MongoDB\Listener;
+
+use App\Document\Face;
+use Doctrine\Bundle\MongoDBBundle\Attribute\AsDocumentListener;
+use Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs;
+use Doctrine\ODM\MongoDB\Events;
+
+use function array_map;
+
+#[AsDocumentListener(Events::loadClassMetadata)]
+class VectorSearchIndexListener
+{
+    public function loadClassMetadata(LoadClassMetadataEventArgs $args): void
+    {
+        $classMetadata = $args->getClassMetadata();
+
+        if ($classMetadata->name !== Face::class) {
+            return;
+        }
+
+        // Remove the original search index definition - ODM only supports Atlas Text Search
+        $searchIndexes = array_map(
+            static function (array $index) {
+                if ($index['name'] !== 'faces' || ($index['type'] ?? null) === 'vectorSearch') {
+                    return $index;
+                }
+
+                $index['type'] = 'vectorSearch';
+                $index['definition']['fields'] = $index['definition']['mappings']['fields'];
+                unset($index['definition']['mappings']);
+
+                return $index;
+            },
+            $classMetadata->searchIndexes,
+        );
+
+        // A big no-no: override the search indexes
+        $classMetadata->searchIndexes = $searchIndexes;
+    }
+}

--- a/src/Document/Face.php
+++ b/src/Document/Face.php
@@ -10,10 +10,12 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 #[ODM\SearchIndex(
     name: 'faces',
     fields: [
-        'numDimensions' => 1024,
-        'path' => 'embeddings',
-        'similarity' => 'euclidean',
-        'type' => 'vector',
+        [
+            'numDimensions' => 1024,
+            'path' => 'embeddings',
+            'similarity' => 'euclidean',
+            'type' => 'vector',
+        ],
     ],
 )]
 class Face

--- a/tests/Document/FaceTest.php
+++ b/tests/Document/FaceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Document;
+
+use App\Document\Face;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class FaceTest extends KernelTestCase
+{
+    public function testSearchIndex(): void
+    {
+        self::bootKernel();
+
+        $classMetadata = $this->getContainer()
+            ->get('doctrine_mongodb.odm.default_document_manager')
+            ->getClassMetadata(Face::class);
+
+        $this->assertEquals(
+            [
+                [
+                    'name' => 'faces',
+                    'type' => 'vectorSearch',
+                    'definition' => [
+                        'fields' => [
+                            [
+                                'numDimensions' => 1024,
+                                'path' => 'embeddings',
+                                'similarity' => 'euclidean',
+                                'type' => 'vector',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $classMetadata->searchIndexes,
+        );
+    }
+}


### PR DESCRIPTION
Since the `SearchIndex` mapping attribute doesn't support vector search indexes yet, this PR adds an event listener to work around the issue. This listener handles the `loadClassMetadata` event and reshapes the index definition of the search index to match the vector search format. Specifically, we set the `type` attribute and extract the `fields` from the `mappings` definition, as this differs from text search indexes.

Note that this PR completely ignores the `readonly` designation (through a docblock) of the `searchIndexes` field in ClassMetadata, but I hope that we can add support for vector search indexes to ODM soon.