### PR TITLE
Add match page

### DIFF
--- a/src/Controller/FaceController.php
+++ b/src/Controller/FaceController.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
+use function array_slice;
+
 class FaceController extends AbstractController
 {
     #[Route('/picture/{id}', name: 'face_picture', methods: ['GET'])]
@@ -46,6 +48,26 @@ class FaceController extends AbstractController
         return $this->render('face/show.html.twig', [
             'face' => $face,
             'similar_faces' => $pictureService->findSimilarPictures($face),
+        ]);
+    }
+
+    #[Route('/match/{id}', name: 'face_show', methods: ['GET'])]
+    public function match(Face $face, PictureService $pictureService, DocumentManager $dm): Response
+    {
+        $similarPictures = $pictureService->findSimilarPictures($face);
+
+        // TODO: What if no similar pictures were found?
+
+        if ($face->mostSimilar === null) {
+            $candidates = array_slice($similarPictures, 0, 3);
+
+            $pictureService->findMostSimilarFace($face, ...$candidates);
+        }
+
+        return $this->render('face/match.html.twig', [
+            'face' => $face,
+            'most_similar_face' => $face->mostSimilar,
+            'similar_faces' => $similarPictures,
         ]);
     }
 

--- a/src/Document/Face.php
+++ b/src/Document/Face.php
@@ -65,4 +65,7 @@ class Face
 
     #[ODM\Field(type: 'date_immutable')]
     public ?\DateTimeImmutable $expiresAt = null;
+
+    #[ODM\ReferenceOne(targetDocument: self::class)]
+    public ?Face $mostSimilar = null;
 }

--- a/src/Service/OpenAI.php
+++ b/src/Service/OpenAI.php
@@ -4,17 +4,25 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use RuntimeException;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
+use function array_merge;
+
 class OpenAI
 {
-    private const PROMPT = <<<'PROMPT'
+    private const ANALYSE_PROMPT = <<<'PROMPT'
     Analyse the picture. It should contain a face or an abstract avatar.
     Describe the face in detail, ignoring everything aside from the face like a background.
     Focus on attributes that can help compare the face to other faces and determine whether the faces are similar.
     If the picture contains multiple faces, describe each face individually.
     Only return a list of individual attributes that can be used for comparison.
+    PROMPT;
+
+    private const FIND_MOST_SIMILAR_PROMPT = <<<'PROMPT'
+    I am giving you a picture of a face, followed by a list of other faces. Number these images from 0.
+    From that list of faces, find the face that is most similar to the first one I provided, then respond with only the number of the most similar image.
     PROMPT;
 
     public function __construct(
@@ -40,7 +48,7 @@ class OpenAI
                     'content' => [
                         [
                             'type' => 'input_text',
-                            'text' => self::PROMPT,
+                            'text' => self::ANALYSE_PROMPT,
                         ],
                         $this->getImageDataPrompt($imageData),
                     ],
@@ -54,5 +62,61 @@ class OpenAI
         ]);
 
         return $response->toArray()['output'][0]['content'][0]['text'];
+    }
+
+    /**
+     * @param string       $imageData  Image data as raw PNG data
+     * @param list<string> $candidates List of candidate images to compare against
+     *
+     * @return list<list<float>>
+     */
+    public function findMostSimilarFace(string $imageData, array $candidates): int
+    {
+        $content = [
+            [
+                'type' => 'input_text',
+                'text' => self::FIND_MOST_SIMILAR_PROMPT,
+            ],
+            $this->getImageDataPrompt($imageData),
+        ];
+
+        $content = array_merge(
+            $content,
+            array_map(
+                fn (string $imageData) => $this->getImageDataPrompt($imageData),
+                $candidates,
+            ),
+        );
+
+        $request = [
+            'model' => 'gpt-4.1-mini',
+            'input' => [
+                [
+                    'role' => 'user',
+                    'content' => $content,
+                ],
+            ],
+        ];
+
+        $response = $this->httpClient->request('POST', 'https://api.openai.com/v1/responses', [
+            'auth_bearer' => $this->apiKey,
+            'json' => $request,
+        ]);
+
+        // Subtract 1 from the index as OpenAI also counts the original image
+        $mostSimilarIndex = ((int) $response->toArray()['output'][0]['content'][0]['text']) - 1;
+
+        return isset($candidates[$mostSimilarIndex])
+            ? $mostSimilarIndex
+            : throw new RuntimeException(sprintf('Invalid index %d returned from OpenAI', $mostSimilarIndex));
+    }
+
+    /** @return array{type: string, image_url: string} */
+    private function getImageDataPrompt(string $imageData): array
+    {
+        return [
+            'type' => 'input_image',
+            'image_url' => 'data:image/png;base64,' . base64_encode($imageData),
+        ];
     }
 }

--- a/src/Service/OpenAI.php
+++ b/src/Service/OpenAI.php
@@ -7,8 +7,6 @@ namespace App\Service;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-use function base64_encode;
-
 class OpenAI
 {
     private const PROMPT = <<<'PROMPT'
@@ -44,10 +42,7 @@ class OpenAI
                             'type' => 'input_text',
                             'text' => self::PROMPT,
                         ],
-                        [
-                            'type' => 'input_image',
-                            'image_url' => 'data:image/png;base64,' . base64_encode($imageData),
-                        ],
+                        $this->getImageDataPrompt($imageData),
                     ],
                 ],
             ],

--- a/src/Service/PictureService.php
+++ b/src/Service/PictureService.php
@@ -14,6 +14,8 @@ use Imagine\Image\Box;
 use Imagine\Image\Format;
 use Imagine\Image\ImageInterface;
 
+use function fclose;
+use function stream_get_contents;
 use function uniqid;
 
 class PictureService
@@ -34,6 +36,22 @@ class PictureService
         $embeddings = $this->voyageAI->generateTextEmbeddings($description);
 
         return [$description, $embeddings];
+    }
+
+    /**
+     * Returns PNG image data for a given face
+     */
+    public function getImageData(Face $face): string
+    {
+        $pictureStream = $this->dm->getRepository(Picture::class)->openDownloadStream($face->file->id);
+
+        try {
+            $imageData = stream_get_contents($pictureStream);
+        } finally {
+            fclose($pictureStream);
+        }
+
+        return new Imagine()->load($imageData)->get(Format::ID_PNG);
     }
 
     public function storePicture(string $filePath, string $originalFileName, string $name = '', bool $temporary = false): Face

--- a/templates/face/match.html.twig
+++ b/templates/face/match.html.twig
@@ -1,0 +1,46 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+<div class="flex justify-center items-center min-h-screen bg-gray-900">
+    <div class="w-[40%] bg-gray-800 rounded-lg shadow-xl p-6 text-center">
+        <h1 class="text-3xl font-bold text-white mb-6">Likely match</h1>
+
+        <div class="grid grid-cols-2 gap-6">
+            <!-- Original Face -->
+            <div class="text-center">
+                <h2 class="text-lg font-bold text-white mb-4">Picture</h2>
+                <img src="{{ path('face_picture', { id: face.id }) }}" alt="{{ face.name }}" class="w-full rounded-lg shadow-lg">
+            </div>
+
+            <!-- Most Similar Face -->
+            <div class="text-center">
+                <h2 class="text-lg font-bold text-white mb-4">{{ most_similar_face.name }}</h2>
+                <img src="{{ path('face_picture', { id: most_similar_face.id }) }}" alt="{{ most_similar_face.name }}" class="w-full rounded-lg shadow-lg">
+            </div>
+
+            <div class="text-center">
+                <p class="mt-4 text-white text-xl font-semibold">{{ face.description|nl2br }}</p>
+            </div>
+
+            <div class="text-center">
+                <p class="mt-4 text-white text-xl font-semibold">{{ most_similar_face.description|nl2br }}</p>
+            </div>
+        </div>
+
+        <div class="grid grid-flow-row auto-rows-max gap-4" style="grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));">
+            <div class="mt-8">
+                <h2 class="text-lg text-white font-bold mb-4">All Similar Faces</h2>
+                <div class="flex flex-wrap justify-center gap-4">
+                    {% for similar in similar_faces %}
+                        <a href="{{ path('face_show', { id: similar.face.id }) }}">
+                            <img src="{{ path('face_picture', { id: similar.face.id }) }}" alt="{{ similar.face.name }}" title="{{ similar.face.name }} - {{ similar.score|format('%.5f') }}" class="w-16 h-16 rounded shadow">
+                        </a>
+                    {% else %}
+                        <p class="text-gray-500">No similar faces found.</p>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/face/show.html.twig
+++ b/templates/face/show.html.twig
@@ -16,7 +16,7 @@
                 <div class="flex flex-wrap justify-center gap-4">
                     {% for similar in similar_faces %}
                         <a href="{{ path('face_show', { id: similar.face.id }) }}">
-                            <img src="{{ path('face_picture', { id: similar.face.id }) }}" alt="{{ similar.face.name }}" class="w-16 h-16 rounded shadow">
+                            <img src="{{ path('face_picture', { id: similar.face.id }) }}" alt="{{ similar.face.name }}" title="{{ similar.face.name }} - {{ similar.score|format('%.5f') }}" class="w-16 h-16 rounded shadow">
                         </a>
                     {% else %}
                         <p class="text-gray-500">No similar faces found.</p>


### PR DESCRIPTION
The new match page shows the original picture side-by-side with the most likely match. To produce better results, we now take the three most likely matches from our vector search and pass those on to OpenAI to let facial analysis do the rest. To reduce the number of AI requests, the most similar result is now stored with the face. This also helps with avoiding inconsistent results.

Note: I have not yet changed the webcam page to redirect to the new match page, but IMO we should do that as it produces a better result.